### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
           echo "::set-output name=RELEASE_VERSION::${release_version}"
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: nguyenvanuyn96/str-find-action
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore